### PR TITLE
Set important flags on disabled border attributes.

### DIFF
--- a/_split_helpers.css.scss
+++ b/_split_helpers.css.scss
@@ -29,12 +29,12 @@
 
 %readonly {
   cursor: no-drop;
-  border: 0;
+  border: 0 !important;
   padding-left: 0;
   color: $colorMediumGrey;
   font-family: monospace;
   padding-top: 0;
-  border-bottom: 1px dashed #eee;
+  border-bottom: 1px dashed #eee !important;
   -webkit-text-fill-color: darken($colorLightGrey, 20%);
   -webkit-opacity: 1;
   background: white;


### PR DESCRIPTION
On fields that contain 'disabled' and are also valid, the disabled border styles should take priority. This fixes https://github.com/sumup/ze-dashboard/issues/224