### PR TITLE
Make checklists wrap properly.

### DIFF
--- a/_split_elements.css.scss
+++ b/_split_elements.css.scss
@@ -70,7 +70,7 @@ ul.checklist {
 
   li {
     @extend %no-margin-bottom;
-    padding: 1em !important;
+    padding: 1em 2em 1em 3em !important;
     border-bottom: 1px solid $colorLightGrey;
     
     &:last-child { border-bottom: none }
@@ -78,11 +78,13 @@ ul.checklist {
     &:before {
       content: '\2714';
       top: .65em;
+      position: absolute;
       left: 0;
       margin-top: -0.7em;
       color: $colorCorpHighlight;
       margin-top: .4em;
       padding-right: 1em;
+      padding-left: 1em;
     }
   }
 


### PR DESCRIPTION
Fixes a wrapping issue where the second line on a long checklist item would go underneath the checkmark instead of staying in line with the first line. Here's what it looks like, fixed:

<img width="275" alt="screen shot 2015-09-17 at 12 06 02" src="https://cloud.githubusercontent.com/assets/1771845/9930526/8eda40b0-5d34-11e5-8796-a5efb8e44754.png">
