### PR TITLE
Made inline inputs use the same width if block mobile or not.

### DIFF
--- a/_split_forms.css.scss
+++ b/_split_forms.css.scss
@@ -50,8 +50,10 @@ label {
 .inline-inputs {
   @include row;
 
+  $width: 48%;
+
   & > li {
-    width: 48%;
+    width: $width;
     padding: 0;
     display: inline-block;
     float: left;
@@ -95,7 +97,7 @@ label {
       }
 
       @include media($breakTabletLandscape) {
-        width: 46%;
+        width: $width;
       }
     }
   }


### PR DESCRIPTION
Hope there wasn't a specific reason they weren't the same :wink: 