### PR TITLE
Bugfix/duplicate styles

### DIFF
--- a/_v2_grid_settings.scss
+++ b/_v2_grid_settings.scss
@@ -9,6 +9,7 @@
 // Styleguide 1.0.
 
 $max-width: 960px;
+$border-box-sizing: false;
 
 //-------------------------------------
 // Overrides for Neat

--- a/_v2_typography.scss
+++ b/_v2_typography.scss
@@ -6,7 +6,7 @@
 // blockquote									- Styles for blockquotes
 // blockquote > span					- Blockquote body
 // blockquote > cite					- Blockquote cite
-// 
+//
 // Styleguide 1.0.
 
 @include font-face(museo-rounded, "https://static.sumup.com/fonts/western-latin/MuseoSansRounded-300-webfont", 300);
@@ -52,11 +52,11 @@ h1, h2, h3, h4 {
 }
 
 h1 {
-	font-size: 2em;
+  font-size: 2em;
 
-	@include media($breakTabletPortrait) { font-size: 2.25em }
+  @include media($breakTabletPortrait) { font-size: 2.25em }
   @include media($breakTabletLandscape) { font-size: 2.5em; }
-	@include media($breakDesktop) { font-size: 2.75em }
+  @include media($breakDesktop) { font-size: 2.75em }
 }
 
 h2 { font-size: 1.6em }


### PR DESCRIPTION
Hey there. I've finally figured out why we have all these duplicate border box sizing rules in the dashboard!
![screen shot 2016-07-06 at 17 01 53](https://cloud.githubusercontent.com/assets/265947/16622797/ae0eb7a6-439b-11e6-892e-130be8d34981.png)

It appears Neat's default setting of `$border-box-sizing: true !default` was causing it. From the `_grid.scss` file:

```sass
/// When set to true, it sets the box-sizing property of all elements to `border-box`. Set with a `!global` flag.
///
/// @type Bool
///
/// @example css - CSS Output
///   html {
///     -webkit-box-sizing: border-box;
///     -moz-box-sizing: border-box;
///     box-sizing: border-box; }
///
///   *, *:before, *:after {
///     -webkit-box-sizing: inherit;
///     -moz-box-sizing: inherit;
///     box-sizing: inherit;
///   }

$border-box-sizing: true !default;
```

By overwriting this in `_v2_grid_settings.scss` the issue is fixed in the dashboard with no obvious new issues. I also saw that we do this anyway in `_layouts.scss`:

```sass
* { @include box-sizing(border-box) }
```

@nilsborchers Do you have any specific feeling about this setting? I don't have any experience with the specifics of box-sizing. Otherwise let's please merge this so dev-tools in Safari work again 😆 